### PR TITLE
Fixes for issues #184 and #186

### DIFF
--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -136,6 +136,7 @@ blockquote {
 
 header.navbar {
   width: 100%;
+  z-index: 2;
 
   border-radius: 0;
   border-bottom: 6px solid #1e95f9;
@@ -171,6 +172,7 @@ header.navbar {
     color: white;
     font-size: 18px;
     font-weight: 400;
+    background: #000;
   }
 
   .nav li a:hover {
@@ -204,6 +206,21 @@ header.navbar {
 
   .searchbox {
     margin-left: 20px;
+  }
+}
+
+@media (max-width: 768px) {
+  header.navbar {
+    .searchbox {
+      background: #fff;
+      margin: 0px;
+    }
+    .navbar-collapse {
+      padding: 0;
+    }
+    .navbar-form, .navbar-nav {
+      margin: 0;
+    }
   }
 }
 


### PR DESCRIPTION
This request includes CSS changes attempting fixes for issues #184 and #186.

Issue #184: Issue appears to be due to how box sizes are decided before applying the chevron to the width. Fixed this by instead having menu items as blocks which clear the chevrons. Padding was then added to put spacing between the items.

Issue #186: It fixes the coloring, z-index and margins of the search box at screen resolutions below 768px. This fixes both the functional issues (unable to click the text box due to being behind the navigation), and the aesthetic issues (the Sign In and Sign Up buttons were white text with no background, the margins were all wrong).

Tested on Firefox 27.0.1, Chrome 33.0.1750.152, and Safari 6.1.1 (8537.73.11) on OS X 10.8. 
