### PR TITLE
Fix date parsing issues on https://scirate.com/search

### DIFF
--- a/lib/search.rb
+++ b/lib/search.rb
@@ -430,22 +430,26 @@ class Search::Paper::Query
   end
 
   def parse_date_range(term)
+    term = term.gsub('\\', '')
     if term.include?('..')
       first, last = term.split('..').map { |t| parse_date(t) }
-      first ||= 1000.years.ago
-      last ||= Time.now
-      first..last
     else
       # Allow implicit ranges like date:2012
       time = parse_date(term)
       if term.match(/^\d\d\d\d$/)
-        time.beginning_of_year..time.end_of_year
+        first = time.beginning_of_year
+        last = time.end_of_year
       elsif term.match(/^\d\d\d\d-\d\d$/)
-        time.beginning_of_month..time.end_of_month
+        first = time.beginning_of_month
+        last = time.end_of_month
       else
-        time.beginning_of_day..time.end_of_day
+        first = time.beginning_of_day
+        last = time.end_of_day
       end
     end
+    first ||= 1000.years.ago
+    last ||= Time.now
+    first..last
   end
 
   def initialize(basic, advanced)


### PR DESCRIPTION
fixes #327 

## Overview
On some inspection, the URLs that use years to search are fine, but searching by month or day does not work.
* Working: https://scirate.com/search?utf8=%E2%9C%93&q=monte+carlo&advanced=au%3A%28Ronald+Fisch%29+in%3Acond-mat+date%3A2009..2010#results
* Working: https://scirate.com/search?utf8=%E2%9C%93&q=monte+carlo&advanced=au%3A%28Ronald+Fisch%29+in%3Acond-mat+date%3A2009#results
* Not working: https://scirate.com/search?utf8=%E2%9C%93&q=monte+carlo&advanced=au%3A%28Ronald+Fisch%29+in%3Acond-mat+date%3A2009-01..2010-01#results
* Not working: https://scirate.com/search?utf8=%E2%9C%93&q=monte+carlo&advanced=au%3A%28Ronald+Fisch%29+in%3Acond-mat+date%3A2009-01#results

## Why the bug happens
1. The code runs `tstrip` on the term:
https://github.com/scirate/scirate/blob/master/lib/search.rb#L488
2. `tstrip` runs partial_sanitize:
https://github.com/scirate/scirate/blob/master/lib/search.rb#L404-L410
3. partial_sanitize escapes the hyphen in the URL:
https://github.com/scirate/scirate/blob/master/lib/search.rb#L38-L39

## Fix
* To remove the escape characters `\\`, one can `gsub` them away. 
* To prevent the "Something has gone wrong" URL, we can always substitute `first` and `last` with the defaults, even when the date range is implicit.


## Caveats
Unfortunately, I did not get this project set up all the way, so I haven't personally tested this. I would love if someone who has this running locally could try it out.