### PR TITLE
Do not require authentication to download JSON file with scites

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -49,10 +49,6 @@ class ApiController < ApplicationController
     render json: { success: true }
   end
 
-  def download_scites
-    render json: current_user.scited_papers
-  end
-
   # Retrieve or update misc. user account settings
   def settings
     settings = [:expand_abstracts]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,6 +42,10 @@ class UsersController < ApplicationController
     render 'users/profile'
   end
 
+  def download_scites
+    render json: @user.scited_papers
+  end
+
   def comments
     @tab = :comments
 

--- a/app/views/users/profile.html.slim
+++ b/app/views/users/profile.html.slim
@@ -73,7 +73,7 @@
           a.btn.btn-default href=(settings_path)
             i.fa.fa-fw.fa-pencil
             | Edit profile
-          a.btn.btn-default href=(download_scites_path)
+          a.btn.btn-default href=(user_download_scites_path @user)
             i.fa.fa-fw.fa-download
             | Download Scites (JSON)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,6 @@ SciRate::Application.routes.draw do
   root 'feeds#index'
 
   get '/search', to: 'papers#search', as: 'papers_search'
-  get '/download_scites', to: 'api#download_scites', as: 'download_scites'
 
   post '/api/scite/:paper_uid', to: 'api#scite',
        as: :scite, paper_uid: /.+/
@@ -83,6 +82,7 @@ SciRate::Application.routes.draw do
   post '/admin/users/:username/update', to: 'admin/users#update', as: 'admin_update_user'
   post '/admin/users/:username/become', to: 'admin/users#become', as: 'admin_become_user'
 
+  get '/:username/download_scites', to: 'users#download_scites', username: /.+/, as: 'user_download_scites'
   get '/:username/scites', to: 'users#scites', username: /.+/, as: 'user_scites'
   get '/:username/comments', to: 'users#comments', username: /.+/, as: 'user_comments'
   get '/:username/papers', to: 'users#papers', username: /.+/, as: 'user_papers'


### PR DESCRIPTION
The list of scites of a user is currently public, but it can be downloaded in JSON format only by the user who made them after authenticating. I do not see why this should be case.

This change should remove the ```/download_scites``` route and add a ```/:username/download_scite```, which should not require authentication. The button "Download scites" on the user profile should direct to this link, so that nothing changes on the UI side.

I am not proficient in Ruby and I did not have the time to set up the development environment to check if this actually works. Sorry! I was hoping this pull request might stimulate some maintainer to implement this change, which should not be particularly complex.