### PR TITLE
corrects google font loading syntax; closes #385

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -40,7 +40,7 @@ html lang="en"
       meta property="og:locale" content="en_US"
       meta property="og:description" content=(@description)
 
-      link href="https://fonts.googleapis.com/css2?family=Sen&Marmelad&display=swap" rel="stylesheet"
+      link href="https://fonts.googleapis.com/css2?family=Sen&display=swap" rel="stylesheet"
 
       = yield :meta
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -40,7 +40,7 @@ html lang="en"
       meta property="og:locale" content="en_US"
       meta property="og:description" content=(@description)
 
-      link href="https://fonts.googleapis.com/css2?family=Sen+Marmelad&display=swap" rel="stylesheet"
+      link href="https://fonts.googleapis.com/css2?family=Sen&Marmelad&display=swap" rel="stylesheet"
 
       = yield :meta
 


### PR DESCRIPTION
Pretty simple one - the syntax for multiple font imports is `&` not `+` (+ concatenates multi-word fonts).

I'm curious though - where does the css live that sets Marmelad as a fonts? Sen is required for Bootstrap from what I can tell, but it looks like Marmelad is unused, unless I'm missing something?