### PR TITLE
makes search bar only visible upon login; closes #384

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -85,11 +85,11 @@ html lang="en"
                 span.staging title="This site is used to test new SciRate features. If you want to use SciRate, please head to https://scirate.com/ instead. Data preservation here is not guaranteed."
                   |  dev
         nav.collapse.navbar-collapse role="navigation"
-          = form_tag papers_search_path, method: 'get', class: 'searchbox navbar-form navbar-right' do
-            = text_field_tag :q, params[:q], placeholder: 'Search', class: 'form-control'
           ul.nav.navbar-nav.navbar-right
             - cache [:header, current_user] do
               - if signed_in?
+                = form_tag papers_search_path, method: 'get', class: 'searchbox navbar-form navbar-right' do
+                  = text_field_tag :q, params[:q], placeholder: 'Search', class: 'form-control'
                 li= link_to "Home", root_path
                 - if current_user.can_admin?
                   li


### PR DESCRIPTION
Search bar moved within the logged in user logic.

Do you think there needs to be some affordance showing that the search is available upon logging in (for the benefit of existing users), or is it just intuitive enough to let them figure it out?

Rspec tests all pass.

Logged in:
![logged-in](https://user-images.githubusercontent.com/4337740/94804422-232b9e80-042e-11eb-9eae-be6d85b5c0a9.png)

Logged out:
![logged-out](https://user-images.githubusercontent.com/4337740/94804428-245ccb80-042e-11eb-8a0a-1dd54015f7a3.png)
