### PR TITLE
implements recaptcha v2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,8 @@
+require 'net/https'
+
 class ApplicationController < ActionController::Base
   protect_from_forgery
+  RECAPTCHA_MINIMUM_SCORE = 0.5
 
   include SessionsHelper
 
@@ -16,4 +19,15 @@ class ApplicationController < ActionController::Base
     return true
   end
 
+  def verify_recaptcha?(token, recaptcha_action)
+    
+    uri = URI('https://www.google.com/recaptcha/api/siteverify')
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    req = Net::HTTP::Post.new(uri.path, {'Content-Type' =>'application/json'})
+    req.set_form_data("secret" => Settings::RECAPTCHA_SECRET_KEY, "response" => token)
+    res = http.request(req)
+    json = JSON.parse(res.body)
+    json['success'] && json['score'] > RECAPTCHA_MINIMUM_SCORE && json['action'] == recaptcha_action
+  end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -124,6 +124,8 @@ html lang="en"
 
     script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 
+    script type="text/javascript" src="https://www.google.com/recaptcha/api.js"
+
     javascript:
       SciRate.current_user = #{raw (current_user ? current_user.to_js : false)};
       SciRate.scited_by_uid = #{raw @scited_by_uid.to_json};

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -22,14 +22,10 @@
         .form-group
           = f.label :password
           = f.password_field :password, class: 'form-control'
-        div.g-recaptcha data-sitekey="6LfagtMZAAAAAOqXnT9v7iCbF1SbHfmxe3x8ttId" data-callback="showButton" data-expired-callback="hideButton"
-        = f.submit "Sign up", class: 'btn btn-default', id: 'submit-button', style: "display: none"
+        = f.submit "Sign up", class: 'btn btn-default g-recaptcha', 'data-sitekey': '6Lf7Q9QZAAAAAEHmCmtNAxA6svUoG-YMXSX8sBR0', 'data-action': 'submit', 'data-callback': 'onSubmit'
 
 javascript:
-  function showButton() {
-    document.getElementById("submit-button").style = "margin-top: 1em";
-  }
+  function onSubmit(token) {
+     document.getElementById("new_user").submit();
+   }
 
-  function hideButton() {
-    document.getElementById("submit-button").style = "display: none";
-  }

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -22,4 +22,14 @@
         .form-group
           = f.label :password
           = f.password_field :password, class: 'form-control'
-        = f.submit "Sign up", class: 'btn btn-default'
+        div.g-recaptcha data-sitekey="6LfagtMZAAAAAOqXnT9v7iCbF1SbHfmxe3x8ttId" data-callback="showButton" data-expired-callback="hideButton"
+        = f.submit "Sign up", class: 'btn btn-default', id: 'submit-button', style: "display: none"
+
+javascript:
+  function showButton() {
+    document.getElementById("submit-button").style = "margin-top: 1em";
+  }
+
+  function hideButton() {
+    document.getElementById("submit-button").style = "display: none";
+  }


### PR DESCRIPTION
This should be sufficient - It depends on the nature of the bot signups - details after the screenshots.

This replaces the signup submit button with a "I'm not a robot" checkbox, which triggers a challenge.

Successful completion reveals the sign up button.
![recaptcha-success](https://user-images.githubusercontent.com/4337740/95015247-a3a10800-0697-11eb-975b-4b8bc6a8badf.gif)

Token expiration removes the button.
![recaptcha-expired](https://user-images.githubusercontent.com/4337740/95015301-d6e39700-0697-11eb-907d-fc133a8f1b9f.gif)

## To consider

It is possible to circumvent the challenge by manually removing the `display: none` style from the button - as far as I can tell this seems to be how most handle recaptcha on the client side - presumably the bots are naive enough to be put off by this?

If we want something more robust we can use a server-side interpretation of the challenge response instead?

