### PR TITLE
allow ORCiD as author identifier

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,7 @@ class User < ActiveRecord::Base
             format: { with: valid_username_regex, message: "may only contain alphanumeric characters and - or _" },
                     uniqueness: { case_sensitive: false }
 
-  valid_aid_regex = /\A[a-z0-9_]+\z/
+  valid_aid_regex = /\A[a-z0-9_\-]+\z/
   validates :author_identifier,
             format: { with: valid_aid_regex, message: "must be a valid arXiv author id" },
             allow_blank: true


### PR DESCRIPTION
:wave: arXiv allows ORCiD in place of author identifiers, as described here:
https://arxiv.org/help/author_identifiers

For example, I would like to use https://arxiv.org/a/0000-0001-9084-6971.html instead of opting-in to a arXiv-specific author identifier.

This change makes that possible by saving the ORCiD ID (i.e. "0000-0001-9084-6971") in the author_identifier field.