### PR TITLE
Only search by sciter_ids if present

### DIFF
--- a/app/lib/search.rb
+++ b/app/lib/search.rb
@@ -495,7 +495,10 @@ class Search::Paper::Query
           ids = User.where(fullname: name).pluck(:id)
         end
 
-        @es_query << 'sciter_ids:' + '(' + ids.join(" OR ") + ')'
+        puts "scited_by:" + ids.join(",")
+        if !ids.empty?
+          @es_query << 'sciter_ids:' + '(' + ids.join(" OR ") + ')'
+        end
       elsif term.start_with?('order:')
         @orders << tstrip(term).to_sym
       elsif term.start_with?('date:')


### PR DESCRIPTION
fixes #409 

I tested locally and this search failed when it found no users and succeeded when it found users.

I think the logging line is helpful, but feel free to remove it.

This makes sense, given the error in the issue:
>    [400] {"error":{"root_cause":[{"type":"query_shard_exception","reason":"Failed to parse query [self\\-calibration sciter_ids:()]","index_uuid":"z8Ugx_tESaizBVXo1R1AXQ","index":"scirate_live_1609609185"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"scirate_live_1609609185","node":"QpR9fHxdThWfvxPQLcdY8g","reason":{"type":"query_shard_exception","reason":"Failed to parse query [self\\-calibration sciter_ids:()]","index_uuid":"z8Ugx_tESaizBVXo1R1AXQ","index":"scirate_live_1609609185","caused_by":{"type":"parse_exception","reason":"Cannot parse 'self\\-calibration sciter_ids:()': Encountered \" \")\" \") \"\" at line 1, column 30.\nWas expecting one of:\n    <NOT> ...\n    \"+\" ...\n    \"-\" ...\n    <BAREOPER> ...\n    \"(\" ...\n    \"*\" ...\n    <QUOTED> ...\n    <TERM> ...\n    <PREFIXTERM> ...\n    <WILDTERM> ...\n    <REGEXPTERM> ...\n    \"[\" ...\n    \"{\" ...\n    <NUMBER> ...\n    <TERM> ...\n    ","caused_by":{"type":"parse_exception","reason":"Encountered \" \")\" \") \"\" at line 1, column 30.\nWas expecting one of:\n    <NOT> ...\n    \"+\" ...\n    \"-\" ...\n    <BAREOPER> ...\n    \"(\" ...\n    \"*\" ...\n    <QUOTED> ...\n    <TERM> ...\n    <PREFIXTERM> ...\n    <WILDTERM> ...\n    <REGEXPTERM> ...\n    \"[\" ...\n    \"{\" ...\n    <NUMBER> ...\n    <TERM> ...\n    "}}}}]},"status":400}