### PR TITLE
Only initialize with last day's data

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -116,7 +116,7 @@ This will initialize the database and Elasticsearch, download the basic feed lay
 rake arxiv:oai_update
 ```
 
-When run for the first time, this will download and index paper metadata from the last day. Subsequent calls will download all metadata since the last time. The production server runs this task every day to keep the database in sync.
+When run for the first time, this will download and index paper metadata from the last 7 days. Subsequent calls will download all metadata since the last time. The production server runs this task every day to keep the database in sync.
 
 ## Testing
 

--- a/lib/tasks/arxiv_oai_update.rake
+++ b/lib/tasks/arxiv_oai_update.rake
@@ -8,7 +8,7 @@ namespace :arxiv do
     last_paper = Paper.order("submit_date desc").first
 
     if last_paper.nil?
-      fromdate = Time.now-7.days
+      fromdate = Time.now-1.days
     else
       fromdate = last_paper.pubdate
     end

--- a/lib/tasks/arxiv_oai_update.rake
+++ b/lib/tasks/arxiv_oai_update.rake
@@ -8,7 +8,7 @@ namespace :arxiv do
     last_paper = Paper.order("submit_date desc").first
 
     if last_paper.nil?
-      fromdate = Time.now-1.days
+      fromdate = Time.now-7.days
     else
       fromdate = last_paper.pubdate
     end


### PR DESCRIPTION
The README specifies that the first run of oai_update only downloads the last day's papers:
> When run for the first time, this will download and index paper metadata from the last day. Subsequent calls will download all metadata since the last time. The production server runs this task every day to keep the database in sync.

This changes the functionality to match the docs. 
I don't know if there are issues if arXiv hasn't updated in a few days, so it may be better to change the docs instead.