### PR TITLE
Dont error when ?page is sent incorrectly

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -31,9 +31,10 @@ class Admin::BaseController < ApplicationController
       end
     end
 
-    @page = params.fetch(:page, 1).to_i
+    @page = [1, params.fetch(:page, 1).to_i].max
     @per_page = 20
-    @pagination = WillPaginate::Collection.new(@page, @per_page, User.count)
+    max_pages = (User.count / (@per_page + 0.0)).ceil()
+    @pagination = WillPaginate::Collection.new([@page, max_pages].min, @per_page, User.count)
     @users = User.order('created_at DESC')
                 .limit(@per_page)
                 .offset((@page-1)*@per_page)

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -33,7 +33,7 @@ class Admin::BaseController < ApplicationController
 
     @page = [1, params.fetch(:page, 1).to_i].max
     @per_page = 20
-    max_pages = (User.count / (@per_page + 0.0)).ceil()
+    max_pages = (User.count / (@per_page + 0.0)).floor() + 1
     @pagination = WillPaginate::Collection.new([@page, max_pages].min, @per_page, User.count)
     @users = User.order('created_at DESC')
                 .limit(@per_page)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
   before_action  :check_moderation_permission, only: [:edit, :delete, :restore]
 
   def index
-    @page = params.fetch(:page, 1).to_i
+    @page = [1, params.fetch(:page, 1).to_i].max
     @per_page = 50
 
     feed_uids = if params[:feed]

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -238,7 +238,7 @@ class FeedsController < ApplicationController
       paper
     end
 
-    max_pages = (res["hits"]["total"]["value"] / (per_page + 0.0)).ceil()
+    max_pages = (res["hits"]["total"]["value"] / (per_page + 0.0)).floor() + 1
     pagination = WillPaginate::Collection.new([page, max_pages].min, per_page, res["hits"]["total"]["value"])
 
     return [papers, pagination]

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -106,7 +106,7 @@ class FeedsController < ApplicationController
   def parse_params
     @date = _parse_date(params)
     @range = _parse_range(params)
-    @page = params[:page] || 1
+    @page = [1, params.fetch(:page, 1).to_i].max
 
     if signed_in?
       if @range.nil?
@@ -238,7 +238,8 @@ class FeedsController < ApplicationController
       paper
     end
 
-    pagination = WillPaginate::Collection.new(page, per_page, res["hits"]["total"]["value"])
+    max_pages = (res["hits"]["total"]["value"] / (per_page + 0.0)).ceil()
+    pagination = WillPaginate::Collection.new([page, max_pages].min, per_page, res["hits"]["total"]["value"])
 
     return [papers, pagination]
   end


### PR DESCRIPTION
Previously sending ?page=0 or ?page=k where k>max number of pages causes 400 and 500 http errors. It also emails me which is annoying. This makes the page load the smallest or largest page possible.