### PR TITLE
remove disallow /

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,5 @@ User-agent: *
 Allow: /about
 Allow: /comments
 Allow: /legal
-Disallow: /
 Disallow: /arxiv
 


### PR DESCRIPTION
As raised in issue [ 516](https://github.com/scirate/scirate/issues/516), `Disallow: \` is effectively blocking crawlers from seeing the webpage and allowing important icons and descriptions to be seen. Removing this will improve SEO/page rank and will allow for descriptions to be seen. In the future if there are api's to block, etc. (to prevent excess requests from bots) we can disallow these. :)