### PR TITLE
Prevent hashes in url params

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -31,7 +31,7 @@ class Admin::BaseController < ApplicationController
       end
     end
 
-    @page = [1, params.fetch(:page, 1).to_i].max
+    @page = [1, params.fetch(:page, 1).to_s.to_i].max
     @per_page = 20
     max_pages = (User.count / (@per_page + 0.0)).floor() + 1
     @pagination = WillPaginate::Collection.new([@page, max_pages].min, @per_page, User.count)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
   before_action  :check_moderation_permission, only: [:edit, :delete, :restore]
 
   def index
-    @page = [1, params.fetch(:page, 1).to_i].max
+    @page = [1, params.fetch(:page, 1).to_s.to_i].max
     @per_page = 50
 
     feed_uids = if params[:feed]

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -106,7 +106,7 @@ class FeedsController < ApplicationController
   def parse_params
     @date = _parse_date(params)
     @range = _parse_range(params)
-    @page = [1, params.fetch(:page, 1).to_i].max
+    @page = [1, params.fetch(:page, 1).to_s.to_i].max
 
     if signed_in?
       if @range.nil?
@@ -135,7 +135,7 @@ class FeedsController < ApplicationController
     return nil unless params.has_key?(:range)
     return :since_last if params[:range] == 'since_last'
 
-    range = params[:range].to_i
+    range = params[:range].to_s.to_i
 
     # negative date windows are confusing
     range = 0 if range < 0

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -35,7 +35,7 @@ class PapersController < ApplicationController
   def search
     basic = params[:q]
     advanced = params[:advanced]
-    page = params[:page] ? params[:page].to_i : 1
+    page = [1, params.fetch(:page, 1).to_s.to_i].max
 
     @search = Search::Paper::Query.new(basic, advanced)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,7 +43,7 @@ class UsersController < ApplicationController
   end
 
   def download_scites
-    @page = [1, params.fetch(:page, 1).to_i].max
+    @page = [1, params.fetch(:page, 1).to_s.to_i].max
     @per_page = 1000
 
     @scited_papers = @user.scited_papers


### PR DESCRIPTION
sometimes people would send urls like https://scirate.com?page[1]=1 which ruby rails interprets the page parameter as a dictionary. This used to give 500s, and now should prevent it.