### PR TITLE
Force parameters to be utf8-sanitized

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'omniauth-rails_csrf_protection'
 gem 'oai', github: 'scirate/ruby-oai'
 gem 'arxivsync', github: 'scirate/arxivsync'
 gem "nokogiri", ">= 1.13.4"
-
+gem 'rack-utf8_sanitizer'
 
 # Elasticsearch API gem
 gem 'elasticsearch'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,8 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack-utf8_sanitizer (1.10.1)
+      rack (>= 1.0, < 4.0)
     rails (6.1.0)
       actioncable (= 6.1.0)
       actionmailbox (= 6.1.0)
@@ -414,6 +416,7 @@ DEPENDENCIES
   pry-byebug (~> 3.9.0)
   pry-rails
   puma (>= 5.6.4)
+  rack-utf8_sanitizer
   rails (= 6.1.0)
   rails-controller-testing
   rspec-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ end
 
 module SciRate
   class Application < Rails::Application
+    config.middleware.insert 0, Rack::UTF8Sanitizer
+
     # HACK
     def self.notify_error(exception, message = nil)
       if exception.is_a?(String)


### PR DESCRIPTION
This prevents most "bad request" errors we receive from bots sending random spam.