### PR TITLE
feat: implement JSON API for papers and feeds

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,6 +59,16 @@ and visit <http://localhost:3000> and you will be looking at SciRate!
 
 It may not be possible to make new users locally. If you get stuck, you can disable the `unless verify_recaptcha` code block in `app/controllers/users_controller.rb` and it should work.
 
+## API Access
+
+SciRate supports JSON responses for several key areas. You can test these locally using curl or by appending .json to the URLs:
+
+Individual Papers: GET /arxiv/:paper_uid.json returns paper metadata, abstracts, and comments.
+
+Feeds & Categories: GET /search.json or GET /arxiv/:category.json returns lists of papers with their scite counts and author details.
+
+This data structure includes is_scited boolean flags, which respect the current user's session if a cookie is provided.
+
 ## Testing
 
 There is a fairly comprehensive series of unit and integration tests in

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -1,6 +1,7 @@
 require 'data_helpers'
 
 class FeedsController < ApplicationController
+  include PapersHelper
   before_action :parse_params
 
   # No user, and no feed specified: show all papers
@@ -13,7 +14,16 @@ class FeedsController < ApplicationController
     @recent_comments = _recent_comments
     @papers, @pagination = _range_query(nil, @backdate, @date, @page)
 
-    render 'feeds/show', formats: :html
+    respond_to do |format|
+      format.html { render 'feeds/show' }
+      format.json {
+        render json: {
+          date: @date,
+          total_papers: @pagination&.total_entries || 0,
+          papers: @papers.map { |p| format_paper_json(p) }
+        }
+      }
+    end
   end
 
   # Aggregated index feed
@@ -50,7 +60,16 @@ class FeedsController < ApplicationController
 
     @scited_by_uid = current_user.scited_by_uid(@papers)
 
-    render 'feeds/show', formats: :html
+    respond_to do |format|
+      format.html { render 'feeds/show' }
+      format.json { 
+        render json: {
+          date: @date,
+          papers: @papers.map { |p| format_paper_json(p) }
+        }
+      }
+    end
+
   end
 
   # Showing a feed while we aren't signed in
@@ -68,7 +87,16 @@ class FeedsController < ApplicationController
     @recent_comments = _recent_comments(feed_uids)
     @papers, @pagination = _range_query(feed_uids, @backdate, @date, @page)
 
-    render 'feeds/show', formats: :html
+    respond_to do |format|
+      format.html { render 'feeds/show' }
+      format.json { 
+        render json: {
+          feed: @feed.uid,
+          date: @date,
+          papers: @papers.map { |p| format_paper_json(p) }
+        }
+      }
+    end
   end
 
   # Showing a feed
@@ -98,7 +126,16 @@ class FeedsController < ApplicationController
     @papers, @pagination = _range_query(feed_uids, @backdate, @date, @page)
     @scited_by_uid = current_user.scited_by_uid(@papers)
 
-    render 'feeds/show', formats: :html
+    respond_to do |format|
+      format.html { render 'feeds/show' }
+      format.json { 
+        render json: {
+          feed: @feed.uid,
+          date: @date,
+          papers: @papers.map { |p| format_paper_json(p) } 
+        }
+      }
+    end
   end
 
   private
@@ -252,4 +289,5 @@ class FeedsController < ApplicationController
 
     return [papers, pagination]
   end
+
 end

--- a/app/helpers/papers_helper.rb
+++ b/app/helpers/papers_helper.rb
@@ -17,4 +17,24 @@ module PapersHelper
                             conditions: ["submit_date < ?", date])
     prev_paper.nil? ? nil : prev_paper.submit_date
   end
+
+  # Formats a Paper model into a standardized JSON structure.
+  def format_paper_json(paper)
+    {
+      # Core Metadata
+      uid: paper.uid,
+      title: paper.title,
+      authors: paper.authors_fullname,
+      abstract: paper.respond_to?(:abstract) ? paper.abstract : nil,
+      
+      # Scirate Stats
+      scites_count: paper.scites_count,
+      comments_count: paper.comments_count,
+      is_scited: @scited_by_uid&.key?(paper.uid) || false,
+      
+      # Dates
+      pubdate: paper.pubdate,
+      submit_date: paper.submit_date,
+    }
+  end
 end

--- a/spec/controllers/feeds_controller_spec.rb
+++ b/spec/controllers/feeds_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe FeedsController do
+  let!(:user) { FactoryGirl.create(:user) }
+  before { become user }
+
+  describe 'GET index' do
+
+    # Testing JSON
+    context 'when requesting JSON' do
+      before { get :index, format: :json }
+
+      it 'returns a list of papers' do
+        expect(response.response_code).to eq 200
+        json = JSON.parse(response.body)
+        expect(json).to have_key('papers')
+        expect(json).to have_key('date')
+      end
+    end
+  end
+end

--- a/spec/controllers/papers_controller_spec.rb
+++ b/spec/controllers/papers_controller_spec.rb
@@ -14,6 +14,7 @@ describe PapersController do
       expect(response).to render_template('papers/show')
     end
 
+    # Testing HTML
     context 'when params[:id] contains versioning' do
       before { get :show, params: { paper_uid: "#{paper.uid}v1" } }
 
@@ -21,6 +22,22 @@ describe PapersController do
         expect(assigns(:paper).uid).to eq paper.uid
         expect(response.response_code).to eq 200
         expect(response).to render_template('papers/show')
+      end
+    end
+
+    # Testing JSON 
+    context 'when requesting JSON' do
+      before { get :show, params: { paper_uid: paper.uid }, format: :json }
+
+      it 'returns a successful JSON response' do
+        expect(response.response_code).to eq 200
+        expect(response.content_type).to include 'application/json'
+        
+        json = JSON.parse(response.body)
+        expect(json['uid']).to eq paper.uid
+        expect(json['title']).to eq paper.title
+        expect(json).to have_key('scites_count')
+        expect(json).to have_key('is_scited')
       end
     end
   end


### PR DESCRIPTION
trying to address https://github.com/scirate/scirate/issues/534

This PR implements JSON support across core controllers to facilitate machine-readable access to SciRate data, reducing the need for HTML scraping.

Let me know if anything need to be changed (like we could put more or less in the json for instance)