### PR TITLE
Fix nokogiri load failure in local dev on Apple Silicon

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,11 +214,15 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.2)
+    mini_portile2 (2.8.9)
     minitest (5.15.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.9)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     oauth2 (1.4.7)
@@ -380,6 +384,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
The `aarch64-linux` precompiled nokogiri binary requires glibc >= 2.29, which the Debian Buster base image (`docker/Dockerfile`) doesn't have. On Apple Silicon Macs running `docker compose up`, this causes the `web` container to crash with `LoadError: cannot load such file -- nokogiri`.

This removes the broken `aarch64-linux` platform entry from `Gemfile.lock` and adds the generic `ruby` platform, so Bundler compiles nokogiri from source on arm64 hosts instead of using the broken precompiled binary.

Confirmed I can load the website after this change.