### PR TITLE
Preserve display math in imported arXiv abstracts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'omniauth-rails_csrf_protection'
 # arxivsync is our custom gem and can be found at:
 # https://github.com/scirate/arxivsync
 gem 'oai', github: 'scirate/ruby-oai'
-gem 'arxivsync', github: 'scirate/arxivsync'
+gem 'arxivsync', github: 'Qubit-Fernand/arxivsync', branch: 'fix-display-math-delimiters'
 gem "nokogiri", ">= 1.13.4"
 gem 'rack-utf8_sanitizer'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
-  remote: https://github.com/scirate/arxivsync.git
-  revision: 2b3d6cbc931823d7427e44812d9314dc868f4667
+  remote: https://github.com/Qubit-Fernand/arxivsync.git
+  revision: 253b65dfb35494972f3773bb6632688196b3aa5c
+  branch: fix-display-math-delimiters
   specs:
     arxivsync (0.3.2)
       colorize


### PR DESCRIPTION
## Summary

Update SciRate's `arxivsync` dependency to a branch that preserves display math delimited by `$$...$$` during metadata import.

This fixes the malformed fraction reported in #545 for arXiv:2608.06094.

## Root cause

`arxivsync` previously toggled equation mode for every individual `$`. In `$$...$$`, the first two characters therefore opened and immediately closed an empty equation. The formula contents were then passed through `latex-decode` as ordinary text, which stripped grouping braces and corrupted commands such as `\frac`.

The dependency fix treats `$` and `$$` as distinct delimiters and closes math only on the matching delimiter. It includes regression tests for inline math, display math, adjacent inline/display math, and unmatched delimiters.

Dependency PR: scirate/arxivsync#3

## Verification

- Reproduced the corruption from the exact abstract source of arXiv:2608.06094.
- Verified the fixed parser preserves the paper's complete arXiv API abstract exactly.
- Added parser regression tests in `arxivsync`.
- Verified the SciRate lockfile resolves to commit `253b65d` containing the fix.

Full local SciRate setup was not completed because Docker Desktop was not running; a native bundle install also requires the repository's PostgreSQL and shared-mime-info system dependencies. CI uses the repository's Docker environment and should exercise the application suite.

## Deployment note

Existing database rows were imported with corrupted LaTeX, so after deployment the affected papers need to be re-imported or otherwise refreshed for the corrected abstract to appear.

Fixes #545
